### PR TITLE
fix: `brew tap` requiring `style --fix`

### DIFF
--- a/Formula/makensis@2.34.rb
+++ b/Formula/makensis@2.34.rb
@@ -9,10 +9,9 @@ class MakensisAT234 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -46,10 +45,10 @@ class MakensisAT234 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@2.35.rb
+++ b/Formula/makensis@2.35.rb
@@ -9,10 +9,9 @@ class MakensisAT235 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -46,10 +45,10 @@ class MakensisAT235 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@2.36.rb
+++ b/Formula/makensis@2.36.rb
@@ -9,10 +9,9 @@ class MakensisAT236 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -46,10 +45,10 @@ class MakensisAT236 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@2.37.rb
+++ b/Formula/makensis@2.37.rb
@@ -9,10 +9,9 @@ class MakensisAT237 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -46,10 +45,10 @@ class MakensisAT237 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@2.38.rb
+++ b/Formula/makensis@2.38.rb
@@ -9,10 +9,9 @@ class MakensisAT238 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -46,10 +45,10 @@ class MakensisAT238 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@2.39.rb
+++ b/Formula/makensis@2.39.rb
@@ -9,10 +9,9 @@ class MakensisAT239 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -46,10 +45,10 @@ class MakensisAT239 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@2.40.rb
+++ b/Formula/makensis@2.40.rb
@@ -9,10 +9,9 @@ class MakensisAT240 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -46,10 +45,10 @@ class MakensisAT240 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@2.41.rb
+++ b/Formula/makensis@2.41.rb
@@ -9,10 +9,9 @@ class MakensisAT241 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -46,10 +45,10 @@ class MakensisAT241 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@2.42.rb
+++ b/Formula/makensis@2.42.rb
@@ -9,10 +9,9 @@ class MakensisAT242 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -46,10 +45,10 @@ class MakensisAT242 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@2.43.rb
+++ b/Formula/makensis@2.43.rb
@@ -9,10 +9,9 @@ class MakensisAT243 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -46,10 +45,10 @@ class MakensisAT243 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@2.44.rb
+++ b/Formula/makensis@2.44.rb
@@ -9,10 +9,9 @@ class MakensisAT244 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -46,10 +45,10 @@ class MakensisAT244 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@2.45.rb
+++ b/Formula/makensis@2.45.rb
@@ -9,10 +9,9 @@ class MakensisAT245 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -46,10 +45,10 @@ class MakensisAT245 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@2.46.rb
+++ b/Formula/makensis@2.46.rb
@@ -9,10 +9,9 @@ class MakensisAT246 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -46,10 +45,10 @@ class MakensisAT246 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@2.47.rb
+++ b/Formula/makensis@2.47.rb
@@ -9,10 +9,9 @@ class MakensisAT247 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -46,10 +45,10 @@ class MakensisAT247 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@2.48.rb
+++ b/Formula/makensis@2.48.rb
@@ -9,10 +9,9 @@ class MakensisAT248 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -46,10 +45,10 @@ class MakensisAT248 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@2.49.rb
+++ b/Formula/makensis@2.49.rb
@@ -9,10 +9,9 @@ class MakensisAT249 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -46,10 +45,10 @@ class MakensisAT249 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@2.50.rb
+++ b/Formula/makensis@2.50.rb
@@ -9,10 +9,9 @@ class MakensisAT250 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -46,10 +45,10 @@ class MakensisAT250 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@2.51.rb
+++ b/Formula/makensis@2.51.rb
@@ -9,10 +9,9 @@ class MakensisAT251 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -46,10 +45,10 @@ class MakensisAT251 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@3.0.rb
+++ b/Formula/makensis@3.0.rb
@@ -9,10 +9,9 @@ class MakensisAT30 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -44,10 +43,10 @@ class MakensisAT30 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@3.01.rb
+++ b/Formula/makensis@3.01.rb
@@ -9,10 +9,9 @@ class MakensisAT301 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -44,10 +43,10 @@ class MakensisAT301 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@3.02.1.rb
+++ b/Formula/makensis@3.02.1.rb
@@ -9,10 +9,9 @@ class MakensisAT3021 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -44,10 +43,10 @@ class MakensisAT3021 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@3.02.rb
+++ b/Formula/makensis@3.02.rb
@@ -9,10 +9,9 @@ class MakensisAT302 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -44,10 +43,10 @@ class MakensisAT302 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@3.03.rb
+++ b/Formula/makensis@3.03.rb
@@ -9,10 +9,9 @@ class MakensisAT303 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -44,10 +43,10 @@ class MakensisAT303 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@3.04.rb
+++ b/Formula/makensis@3.04.rb
@@ -9,10 +9,9 @@ class MakensisAT304 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -44,10 +43,10 @@ class MakensisAT304 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@3.05.rb
+++ b/Formula/makensis@3.05.rb
@@ -9,10 +9,9 @@ class MakensisAT305 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -44,10 +43,10 @@ class MakensisAT305 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@3.06.1.rb
+++ b/Formula/makensis@3.06.1.rb
@@ -9,10 +9,9 @@ class MakensisAT3061 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -44,10 +43,10 @@ class MakensisAT3061 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path

--- a/Formula/makensis@3.06.rb
+++ b/Formula/makensis@3.06.rb
@@ -9,10 +9,9 @@ class MakensisAT306 < Formula
   end
 
   bottle do
-    cellar :any_skip_relocation
-    sha256 "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef" => :catalina
-    sha256 "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448" => :mojave
-    sha256 "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f" => :high_sierra
+    sha256 cellar: :any_skip_relocation, catalina:    "889d630bf8637f68e90a9591a373ee44bde8d9d6a9395171e024fdced27f26ef"
+    sha256 cellar: :any_skip_relocation, mojave:      "b40f5a388f0dddeb2c3d274bdc43fbba6cc0a9f613d056f0981bc60350252448"
+    sha256 cellar: :any_skip_relocation, high_sierra: "fe92934c874a27ead142b769d1c1258c6fd3baa66f2f005cad3f57ccd759734f"
   end
 
   option "with-advanced-logging", "Enable advanced logging of all installer actions"
@@ -44,10 +43,10 @@ class MakensisAT306 < Formula
 
     system "scons", "makensis", *args
 
-    if build.with? "debug"
-      install_path = "build/udebug/makensis/makensis"
+    install_path = if build.with? "debug"
+      "build/udebug/makensis/makensis"
     else
-      install_path = "build/urelease/makensis/makensis"
+      "build/urelease/makensis/makensis"
     end
 
     bin.install install_path


### PR DESCRIPTION
Resolving error when running `brew tap nsis-dev/makensis` that blocks installing any versioned makensis
Error:
```
Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
```
Run `brew style --fix ./Formula` to resolve.
Output excerpt:
```
homebrew-makensis-0.4.0/Formula/makensis@3.06.rb:11:5: C: [Corrected] sha256 should use new syntax
    sha256 "8f035781e4e926b8dcd367fbdc3a3a2bdd9b5fd96d268da62e9ac88ada495137" => :sierra
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

27 files inspected, 162 offenses detected, 162 offenses corrected
```

Verified install via:
```
brew install ./Formula/makensis@3.06.1.rb --with-advanced-logging --with-large-strings
Error: Failed to load cask: ./Formula/makensis@3.06.1.rb
Cask 'makensis@3.06.1' is unreadable: wrong constant name #<Class:0x00007f8afc23b4f8>
Warning: Treating ./Formula/makensis@3.06.1.rb as a formula
....

==> Installing nsis-dev/makensis/makensis@3.06.1 --with-advanced-logging --with-large-strings
==> scons makensis CC=/usr/bin/clang CXX=/usr/bin/clang++ PREFIX_DOC=/usr/local/Cellar/makensis@3.06.1/3.06.1/share/nsis/Doc
Error: undefined method `name' for nil:NilClass
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/exceptions.rb:271:in `block in initialize'
/usr/local/Homebrew/Library/Homebrew/exceptions.rb:270:in `map'
/usr/local/Homebrew/Library/Homebrew/exceptions.rb:270:in `initialize'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:544:in `new'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:544:in `loader_for'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:412:in `factory'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1694:in `[]'
/usr/local/Homebrew/Library/Homebrew/formula.rb:440:in `block in versioned_formulae'
/usr/local/Homebrew/Library/Homebrew/formula.rb:437:in `map'
/usr/local/Homebrew/Library/Homebrew/formula.rb:437:in `versioned_formulae'
/usr/local/Homebrew/Library/Homebrew/unlink.rb:10:in `unlink_versioned_formulae'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:935:in `link'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:760:in `finish'
/usr/local/Homebrew/Library/Homebrew/install.rb:304:in `install_formula'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:207:in `block in install'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:205:in `each'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:205:in `install'
/usr/local/Homebrew/Library/Homebrew/brew.rb:122:in `<main>'

m@Mikes-iMac /u/l/H/L/T/n/homebrew-makensis> pwd                                                         
/usr/local/Homebrew/Library/Taps/nsis-dev/homebrew-makensis

m@Mikes-iMac /u/l/H/L/T/n/homebrew-makensis> makensis -version                                 
v3.06.1
```

`makensis@3.06.1` seems to install successfully as it registers the correct version via command line as the output excerpt above shows. The error being thrown is related to the linking stage and I don't know what it means (Help wanted plz! 🙂)
Rerunning the install command.
```
brew install ./Formula/makensis@3.06.1.rb --with-advanced-logging --with-large-strings
Error: Failed to load cask: ./Formula/makensis@3.06.1.rb
Cask 'makensis@3.06.1' is unreadable: wrong constant name #<Class:0x00007f86379b37b8>
Warning: Treating ./Formula/makensis@3.06.1.rb as a formula.
Warning: nsis-dev/makensis/makensis@3.06.1 3.06.1 is already installed, it's just not linked.
To link this version, run:
  brew link makensis@3.06.1

m@Mikes-iMac /u/l/H/L/T/n/homebrew-makensis> brew link makensis@3.06.1
Error: undefined method `name' for nil:NilClass
```

How do I verify that `--with-advanced-logging --with-large-strings` these were successful?